### PR TITLE
Add a logger delegate class for logging.

### DIFF
--- a/message_notify.info
+++ b/message_notify.info
@@ -8,6 +8,7 @@ dependencies[] = ctools
 ; Notifier plugins
 files[] = includes/message_notify.exception.inc
 files[] = plugins/notifier/abstract.inc
+files[] = plugins/notifier_logger/abstract.inc
 
 ; Tests
 files[] = message_notify.test

--- a/message_notify.module
+++ b/message_notify.module
@@ -61,6 +61,20 @@ function message_notify_plugin_process(&$plugin, $info) {
     'save on success' => TRUE,
     'language override' => FALSE,
     'rendered fields' => array(),
+    'logger plugin' => 'watchdog',
+  );
+}
+
+/**
+ * Add defaults values to the notifier logger plugins.
+ *
+ * - 'description': The description of the plugin.
+ * - 'options': An array of options.
+ */
+function message_notify_logger_plugin_process(&$plugin, $info) {
+  $plugin += array(
+    'description' => '',
+    'options' => array(),
   );
 }
 
@@ -127,6 +141,9 @@ function message_notify_ctools_plugin_api($module, $api) {
   if ($module == 'message_notify' && $api == 'notifier') {
     return array('version' => 1);
   }
+  if ($module == 'message_notify' && $api == 'notifier_logger') {
+    return array('version' => 1);
+  }
 }
 
 /**
@@ -136,6 +153,10 @@ function message_notify_ctools_plugin_type() {
   $plugins['notifier'] = array(
     'classes' => array('class'),
     'process' => 'message_notify_plugin_process',
+  );
+  $plugins['notifier_logger'] = array(
+    'classes' => array('class'),
+    'process' => 'message_notify_logger_plugin_process',
   );
   return $plugins;
 }

--- a/plugins/notifier/abstract.inc
+++ b/plugins/notifier/abstract.inc
@@ -19,6 +19,15 @@ interface MessageNotifierInterface {
    */
   public function __construct($plugin, Message $message);
 
+
+  /**
+   * Return the plugin definition array that is passed in on construction.
+   *
+   * @return array
+   *   The ctools plugin definiton array.
+   */
+  public function getPluginDefinition();
+
   /**
    * Entry point to send and process a message.
    *
@@ -48,6 +57,11 @@ interface MessageNotifierInterface {
    * Determine if user can access notifier.
    */
   public function access();
+
+  /**
+   * Return an instance of a class for logging send results.
+   */
+  public function getLogger();
 }
 
 /**
@@ -64,6 +78,15 @@ abstract class MessageNotifierBase implements MessageNotifierInterface {
    * The message entity.
    */
   protected $message;
+
+  /**
+   * The logger class for this Notfier.
+   */
+  protected $logger;
+
+  public function getPluginDefinition() {
+    return $this->plugin;
+  }
 
   public function __construct($plugin, Message $message) {
     $this->plugin = $plugin;
@@ -96,12 +119,11 @@ abstract class MessageNotifierBase implements MessageNotifierInterface {
 
     $options = $plugin['options'];
 
+    // Log the result of sending.
+    $this->getLogger()->log($result, $message);
     $save = FALSE;
-    if (!$result) {
-      watchdog('message_notify', t('Could not send message using @title to user ID @uid.'), array('@label' => $plugin['title'], '@uid' => $message->uid), WATCHDOG_ERROR);
-      if ($options['save on fail']) {
-        $save = TRUE;
-      }
+    if (!$result && $options['save on fail']) {
+      $save = TRUE;
     }
     elseif ($result && $options['save on success']) {
       $save = TRUE;
@@ -139,5 +161,19 @@ abstract class MessageNotifierBase implements MessageNotifierInterface {
 
   public function access() {
     return TRUE;
+  }
+
+  public function getLogger() {
+    if (!isset($this->logger)) {
+      $options = $this->plugin['options'];
+      $logger_plugin = $options['logger plugin'];
+
+      ctools_include('plugins');
+      $plugin = ctools_get_plugins('message_notify', 'notifier_logger', $options['logger plugin']);
+
+      $class = ctools_plugin_load_class('message_notify', 'notifier_logger', $logger_plugin, 'class');
+      $this->logger = new $class($plugin, $this);
+    }
+    return $this->logger;
   }
 }

--- a/plugins/notifier_logger/abstract.inc
+++ b/plugins/notifier_logger/abstract.inc
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Interface for logging notification sending of messages.
+ */
+interface MessageNotifierLoggerInterface {
+
+  public function __construct($plugin, MessageNotifierInterface $notifier);
+
+
+  /**
+   * Log the sending of a message.
+   *
+   * @param $result
+   *   The sending result from the notifier class.
+   * @param $message
+   *   The message that was sent.
+   */
+  public function log($result, $message);
+
+}

--- a/plugins/notifier_logger/watchdog/MessageNotifierLoggerWatchdog.class.php
+++ b/plugins/notifier_logger/watchdog/MessageNotifierLoggerWatchdog.class.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Simple class the implements logging to the watchdog.
+ */
+class MessageNotifierLoggerWatchdog implements MessageNotifierLoggerInterface {
+
+  public function __construct($plugin, MessageNotifierInterface $notifier) {
+    $this->plugin = $plugin;
+    $this->notifier = $notifier;
+  }
+
+  public function log($result, $message) {
+    $options = $this->plugin['options'];
+    $notifier_definition = $this->notifier->getPluginDefinition();
+    if (!$result && $options['log on fail']) {
+      watchdog('message_notify', t('Could not send message using @title to user ID @uid.'), array('@title' => $notifier_definition['title'], '@uid' => $message->uid), WATCHDOG_ERROR);
+    }
+    elseif ($result && $options['log on success']) {
+      watchdog('message_notify', t('Sent message using @title to user ID @uid.'), array('@title' => $notifier_definition['title'], '@uid' => $message->uid), WATCHDOG_INFO);
+    }
+  }
+}

--- a/plugins/notifier_logger/watchdog/watchdog.inc
+++ b/plugins/notifier_logger/watchdog/watchdog.inc
@@ -6,6 +6,6 @@ $plugin = array(
   'class' => 'MessageNotifierLoggerWatchdog',
   'options' => array(
     'log on fail' => TRUE,
-    'log on success' => TRUE,
+    'log on success' => FALSE,
   ),
 );

--- a/plugins/notifier_logger/watchdog/watchdog.inc
+++ b/plugins/notifier_logger/watchdog/watchdog.inc
@@ -1,0 +1,11 @@
+<?php
+
+$plugin = array(
+  'title' => t('Watchdog'),
+  'description' => t('Logs failed message notifications to the watchdog.'),
+  'class' => 'MessageNotifierLoggerWatchdog',
+  'options' => array(
+    'log on fail' => TRUE,
+    'log on success' => TRUE,
+  ),
+);


### PR DESCRIPTION
I'd like to be able to swap out the logger for something more exciting that just the watchdog, and I have the need to log success messages, so I figured that a nice way to supply this would be via a logger delegate class that can be easily swapped out.
