### PR TITLE
Fixes fatal error during config import

### DIFF
--- a/message_notify.module
+++ b/message_notify.module
@@ -4,6 +4,8 @@
  * Message notify module.
  */
 
+use Drupal\Core\Entity\Entity\EntityViewMode;
+
 /**
  * Implements hook_mail().
  *
@@ -22,6 +24,11 @@ function message_notify_mail($key, &$message, $params) {
  */
 function message_notify_entity_bundle_create($entity_type_id, $bundle) {
   if ($entity_type_id != 'message') {
+    return;
+  }
+
+  // Do nothing if these view modes are not yet available.
+  if (!EntityViewMode::load('message.mail_body') || !EntityViewMode::load('message.mail_subject')) {
     return;
   }
 


### PR DESCRIPTION
- Under certain conditions, this hook can fire before the 2 custom
  display modes are available, resulting in a fatal error:

```
Fatal error: Call to a member function getConfigDependencyName() on null in /var/www/core/lib/Drupal/Core/Entity/EntityDisplayBase.php on line 279
```
