### PR TITLE
Incorrect watchdog message replacement token

### DIFF
--- a/plugins/notifier/abstract.inc
+++ b/plugins/notifier/abstract.inc
@@ -98,7 +98,7 @@ abstract class MessageNotifierBase implements MessageNotifierInterface {
 
     $save = FALSE;
     if (!$result) {
-      watchdog('message_notify', t('Could not send message using @title to user ID @uid.'), array('@label' => $plugin['title'], '@uid' => $message->uid), WATCHDOG_ERROR);
+      watchdog('message_notify', t('Could not send message using @title to user ID @uid.'), array('@title' => $plugin['title'], '@uid' => $message->uid), WATCHDOG_ERROR);
       if ($options['save on fail']) {
         $save = TRUE;
       }


### PR DESCRIPTION
Just a simple fix to the token name in watchdog() call.

'@title' literally appears in log messages otherwise.

https://www.drupal.org/node/2352969
