### PR TITLE
Do not require a message to construct a notifier.

### DIFF
--- a/src/Plugin/Notifier/Email.php
+++ b/src/Plugin/Notifier/Email.php
@@ -39,7 +39,7 @@ class Email extends MessageNotifierBase {
    * @param \Drupal\Core\Mail\MailManagerInterface $mail_manager
    *   The mail manager service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, LoggerChannelInterface $logger, EntityTypeManagerInterface $entity_type_manager, MessageInterface $message, MailManagerInterface $mail_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, LoggerChannelInterface $logger, EntityTypeManagerInterface $entity_type_manager, MessageInterface $message = NULL, MailManagerInterface $mail_manager) {
     // Set configuration defaults.
     $configuration += [
       'mail' => FALSE,
@@ -71,7 +71,7 @@ class Email extends MessageNotifierBase {
    */
   public function deliver(array $output = []) {
     /** @var \Drupal\user\UserInterface $account */
-    $account = $this->message->uid->entity;
+    $account = $this->message->getOwner();
 
     if (!$this->configuration['mail'] && !$account->id()) {
       // The message has no owner and no mail was passed. This will cause an

--- a/src/Plugin/Notifier/MessageNotifierInterface.php
+++ b/src/Plugin/Notifier/MessageNotifierInterface.php
@@ -5,6 +5,7 @@ namespace Drupal\message_notify\Plugin\Notifier;
 use Drupal\Component\Plugin\DerivativeInspectionInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\message\MessageInterface;
 
 /**
  * Additional behaviors for a Entity Reference field.
@@ -48,5 +49,13 @@ interface MessageNotifierInterface extends ContainerFactoryPluginInterface, Plug
    * Determine if user can access notifier.
    */
   public function access();
+
+  /**
+   * Set the message object for the notifier.
+   *
+   * @param \Drupal\message\MessageInterface $message
+   *   The message object.
+   */
+  public function setMessage(MessageInterface $message);
 
 }

--- a/tests/src/Unit/Plugin/Notifier/EmailTest.php
+++ b/tests/src/Unit/Plugin/Notifier/EmailTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Drupal\Tests\message_notify\Unit\Plugin\Notifier;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityViewBuilderInterface;
+use Drupal\Core\Language\Language;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Mail\MailManagerInterface;
+use Drupal\message\MessageInterface;
+use Drupal\message\MessageTemplateInterface;
+use Drupal\message_notify\Plugin\Notifier\Email;
+use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserInterface;
+
+/**
+ * Unit tests for the Email notifier.
+ *
+ * @coversDefaultClass \Drupal\message_notify\Plugin\Notifier\Email
+ *
+ * @group message_notify
+ */
+class EmailTest extends UnitTestCase {
+
+  /**
+   * Digest configuration.
+   *
+   * @var array
+   */
+  protected $configuration = [];
+
+  /**
+   * Mocked entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The mocked mail manager service.
+   *
+   * @var \Drupal\Core\Mail\MailManagerInterface
+   */
+  protected $mailManager;
+
+  /**
+   * Plugin definition.
+   *
+   * @var array
+   */
+  protected $pluginDefinition = [
+    'viewModes' => [
+      'mail_subject',
+      'mail_body',
+    ],
+  ];
+
+  /**
+   * Plugin ID.
+   *
+   * @var string
+   */
+  protected $pluginId;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class)->reveal();
+    $this->mailManager = $this->prophesize(MailManagerInterface::class)->reveal();
+    $this->pluginId = $this->randomMachineName();
+    $this->pluginDefinition['title'] = $this->randomMachineName();
+  }
+
+  /**
+   * Test the send method.
+   *
+   * @covers ::send
+   * @covers ::setMessage
+   */
+  public function testSend() {
+    // Mock a message object.
+    $message = $this->prophesize(MessageInterface::class);
+    $account = $this->prophesize(UserInterface::class);
+    $account->id()->willReturn(42);
+    $account->getEmail()->willReturn('foo@foo.com');
+    $account->getPreferredLangcode()->willReturn(Language::LANGCODE_DEFAULT);
+    $message->getOwner()->willReturn($account->reveal());
+    $message->getOwnerId()->willReturn(42);
+    $template = $this->prophesize(MessageTemplateInterface::class)->reveal();
+    $message->getTemplate()->willReturn($template);
+
+    // Mock view builder.
+    $view_builder = $this->prophesize(EntityViewBuilderInterface::class)->reveal();
+    $entity_type_manager = $this->prophesize(EntityTypeManagerInterface::class);
+    $entity_type_manager->getViewBuilder('message')->willReturn($view_builder);
+    $this->entityTypeManager = $entity_type_manager->reveal();
+
+    $notifier = $this->getNotifier();
+    $notifier->setMessage($message->reveal());
+    $this->assertNull($notifier->send());
+  }
+
+  /**
+   * Test sending without a message.
+   *
+   * @covers ::send
+   *
+   * @expectedException \AssertionError
+   * @expectedExceptionMessage No message is set for this notifier.
+   */
+  public function testSendNoMessage() {
+    $notifier = $this->getNotifier();
+    $notifier->send();
+  }
+
+  /**
+   * Test sending without an email.
+   *
+   * @covers ::deliver
+   *
+   * @expectedException \Drupal\message_notify\Exception\MessageNotifyException
+   * @expectedExceptionMessage It is not possible to send a Message for an anonymous owner. You may set an owner using ::setOwner() or pass a "mail" to the $options array.
+   */
+  public function testSendNoEmail() {
+    $message = $this->prophesize(MessageInterface::class);
+    $account = $this->prophesize(UserInterface::class)->reveal();
+    $message->getOwner()->willReturn($account);
+    $notifier = $this->getNotifier($message->reveal());
+    $notifier->deliver([]);
+  }
+
+  /**
+   * Constructs an email notifier.
+   *
+   * @param \Drupal\message\MessageInterface $message
+   *   (optional) The message to construct the notifier with.
+   *
+   * @return \Drupal\message_notify\Plugin\Notifier\Email
+   *   The email notifier plugin.
+   */
+  protected function getNotifier(MessageInterface $message = NULL) {
+    $logger = $this->prophesize(LoggerChannelInterface::class)->reveal();
+
+    return new Email(
+      $this->configuration,
+      $this->pluginId,
+      $this->pluginDefinition,
+      $logger,
+      $this->entityTypeManager,
+      $message,
+      $this->mailManager
+    );
+  }
+
+}


### PR DESCRIPTION
- Fixes #32
- Makes the Message object optional when constructing a notifier, and
  adds a `setMessage()` method.
- Adds an assertion to the `send()` method to ensure an actual message
  is set when that is called.
