### PR TITLE
Remove redundant trim.

### DIFF
--- a/src/Plugin/Notifier/Email.php
+++ b/src/Plugin/Notifier/Email.php
@@ -106,7 +106,6 @@ class Email extends MessageNotifierBase {
 
     // The subject in an email can't be with HTML, so strip it.
     $output['mail_subject'] = trim(strip_tags($output['mail_subject']));
-    $output['mail_body'] = $output['mail_body'];
 
     // Pass the message entity along to hook_drupal_mail().
     $output['message_entity'] = $this->message;


### PR DESCRIPTION
I'm not sure why we assign the variable to itself. I looked on how the 7.x-2.x branch [did it](https://github.com/Gizra/message_notify/blob/7.x-2.x/plugins/notifier/email/MessageNotifierEmail.class.php#L26) and this is not there.

