### PR TITLE
Clarify ambiguous wording in exception message

### DIFF
--- a/src/Plugin/Notifier/Email.php
+++ b/src/Plugin/Notifier/Email.php
@@ -92,7 +92,7 @@ class Email extends MessageNotifierBase {
     if (!$this->configuration['mail'] && !$account->id()) {
       // The message has no owner and no mail was passed. This will cause an
       // exception, we just make sure it's a clear one.
-      throw new MessageNotifyException('It is not possible to send a Message for an anonymous owner. You may set an owner using ::setOwner() or pass a "mail" to the $options array.');
+      throw new MessageNotifyException('It is not possible to send a Message to an anonymous owner. You may set an owner using ::setOwner() or pass a "mail" to the $options array.');
     }
 
     $mail = $this->configuration['mail'] ?: $account->getEmail();

--- a/tests/src/Unit/Plugin/Notifier/EmailTest.php
+++ b/tests/src/Unit/Plugin/Notifier/EmailTest.php
@@ -131,7 +131,7 @@ class EmailTest extends UnitTestCase {
    * @covers ::deliver
    *
    * @expectedException \Drupal\message_notify\Exception\MessageNotifyException
-   * @expectedExceptionMessage It is not possible to send a Message for an anonymous owner. You may set an owner using ::setOwner() or pass a "mail" to the $options array.
+   * @expectedExceptionMessage It is not possible to send a Message to an anonymous owner. You may set an owner using ::setOwner() or pass a "mail" to the $options array.
    */
   public function testSendNoEmail() {
     $message = $this->prophesize(MessageInterface::class);


### PR DESCRIPTION
This is a minor improvement to one of the exception messages. I was confused about this wording:

> It is not possible to send a Message for an anonymous owner.

The "for" seems to indicate that the anonymous user is the sender of the message, not the recipient. This is reinforced by the fact that it checks `$message->getOwner()` - in many other entity types the owner is the same as the author, but this is not the case for messages.

I propose to change it so it is clear the message is attempted to be sent TO an anonymous user.