### PR TITLE
Capitalize name of module

### DIFF
--- a/message_notify.info.yml
+++ b/message_notify.info.yml
@@ -1,4 +1,4 @@
-name: 'Message notify'
+name: 'Message Notify'
 description: 'Message notify.'
 core: 8.x
 package: Message


### PR DESCRIPTION
Per Drupal standards we should capitalize the entire title of the modules in order to be consistent: https://www.drupal.org/docs/develop/documenting-your-project/help-text-standards. Here is a small PR to address it. Thanks for your work on this module. :)